### PR TITLE
Prompt for Yubikey use during setup

### DIFF
--- a/lib.sh
+++ b/lib.sh
@@ -177,7 +177,7 @@ function request_2fa_token() {
   echo "🔄 Logging into AWS..." >&2
 
   # Check if Yubikey or 1password are available
-  if ykman=$( which ykman ) && if [[ "${SETUP_AWS_HELPER_YKMAN:-0}" -eq 1 ]]; then
+  if ykman=$( which ykman ) && [[ "${SETUP_AWS_HELPER_YKMAN:-0}" -eq 1 ]]; then
       if [ -z "$( $ykman list )" ]; then
         echo "🔑 Please insert your yubikey and hit <ENTER>..." >&2
         read


### PR DESCRIPTION
This pull request includes changes to the `lib.sh` script to enhance the handling of 2FA (Two-Factor Authentication) with Yubikey and improve user prompts during setup. The most important changes include adding a check for Yubikey usage and updating the setup function to prompt users about using Yubikey for 2FA.

Enhancements to 2FA handling:

* [`lib.sh`](diffhunk://#diff-503615c901c45226b03b60450608983b94776c2b0267f89ca6ef20429007cc66L180-R186): Modified the `request_2fa_token` function to include a condition that checks if the Yubikey client is enabled before attempting to use it for generating the 2FA token.

Improvements to user prompts:

* [`lib.sh`](diffhunk://#diff-503615c901c45226b03b60450608983b94776c2b0267f89ca6ef20429007cc66R293-R297): Updated the `save_setup` function to prompt the user if they use the Yubikey client for 2FA and set the corresponding environment variable if they do.